### PR TITLE
Prettier endOfLine check deleted

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,6 +5,5 @@
   "singleQuote": false,
   "trailingComma": "all",
   "bracketSpacing": true,
-  "arrowParens": "always",
-  "endOfLine": "lf"
+  "arrowParens": "always"
 }


### PR DESCRIPTION
### What does it do
Removes the 'endOfLine' constarint from prettier.config as a way to avoid future conflicts between windows, mac and linux workspaces